### PR TITLE
Replace triplet with arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ features = ["serde_yaml"]
 [dev-dependencies.pretty_assertions]
 version = "0.5"
 
-[target.wasm32-unknown-unknown.dependencies.wasm-bindgen]
+[target.'cfg(target_arch = "wasm32")'.wasm-bindgen]
 version = "0.2"
 features = ["serde-serialize"]
 
-[target.wasm32-unknown-unknown.dependencies.console_error_panic_hook]
+[target.'cfg(target_arch = "wasm32")'.dependencies.console_error_panic_hook]
 version = "0.1"
 
-[target.wasm32-unknown-unknown.dev-dependencies.wasm-bindgen-test]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies.wasm-bindgen-test]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ features = ["serde_yaml"]
 [dev-dependencies.pretty_assertions]
 version = "0.5"
 
-[target.'cfg(target_arch = "wasm32")'.wasm-bindgen]
+[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
 version = "0.2"
 features = ["serde-serialize"]
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This library is written in the Rust language and can be used:
 ## Documentation
 
 * [API documentation]
+* [Changelog]
 
 ## Usage
 
@@ -126,3 +127,4 @@ the [license].
 [license]: https://github.com/balena-io-modules/balena-cdsl/blob/master/LICENSE
 [Rust crate]: https://crates.io/crates/balena-cdsl
 [NPM package]: https://www.npmjs.com/package/balena-cdsl
+[Changelog]: https://github.com/balena-io-modules/balena-cdsl/blob/master/CHANGELOG.md

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -27,7 +27,12 @@ echo "Testing Rust crate..."
 cargo test
 
 echo "Trying to package Rust crate..."
-cargo package
+CARGO_PACKAGE_ARGS=''
+if ! [ "$CI" = true ]; then
+    # Allow to test uncommitted changes locally
+    CARGO_PACKAGE_ARGS='--allow-dirty'
+fi
+cargo package ${CARGO_PACKAGE_ARGS}
 
 ci/build-wasm.sh
 


### PR DESCRIPTION
* Replaces `wasm32-unknown-unknown` triplet with `'cfg(target_arch = "wasm32")'` in Cargo.toml
* Adds changelog link to readme
* Sync `ci/test.sh` with temen to allow test packaging with uncommitted changes locally