### PR TITLE
Normalize min/max property names according to the new spec.

### DIFF
--- a/docs/SPEC_SUPPORT.md
+++ b/docs/SPEC_SUPPORT.md
@@ -27,10 +27,10 @@ Please find a detailed list below - presented in the order they appear in the sp
 
 [Validation keywords for numeric instances](https://github.com/balena-io/balena/blob/832f5551127dd8e1e82fa082bea97fc4db81c3ce/specs/configuration-dsl.md#validation-keywords-for-numeric-instances-number-and-integer)
 * [X] `multipleOf`
-* [X] `maximum`
-* [X] `exclusiveMaximum`
-* [X] `minimum`
-* [X] `exclusiveMinimum`
+* [X] `max`
+* [X] `exclusiveMax`
+* [X] `min`
+* [X] `exclusiveMin`
 
 [Validation keywords for strings](https://github.com/balena-io/balena/blob/832f5551127dd8e1e82fa082bea97fc4db81c3ce/specs/configuration-dsl.md#validation-keywords-for-strings)
 * [X] `maxLength`

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-stable
+beta
+

--- a/src/dsl/schema/object_types/bounds/deserialization.rs
+++ b/src/dsl/schema/object_types/bounds/deserialization.rs
@@ -87,8 +87,8 @@ pub fn deserialize_integer_bounds<E>(mapping: &Mapping) -> Result<Option<Integer
 where
     E: Error,
 {
-    let maximum = deserialize_integer_bound("maximum", mapping)?;
-    let minimum = deserialize_integer_bound("minimum", mapping)?;
+    let maximum = deserialize_integer_bound("max", mapping)?;
+    let minimum = deserialize_integer_bound("min", mapping)?;
     let multiple_of = deserialize_integer("multipleOf", mapping)?;
 
     if maximum.is_some() || minimum.is_some() || multiple_of.is_some() {

--- a/tests/data/numbers/validation/input-schema.yml
+++ b/tests/data/numbers/validation/input-schema.yml
@@ -4,5 +4,5 @@ properties:
 - multiplesOfTen:
     type: integer
     multipleOf: 10
-    minimum: 10
-    exclusiveMaximum: 100
+    min: 10
+    exclusiveMax: 100


### PR DESCRIPTION
This is a breaking change of the DSL schema, as per [spec change](https://github.com/balena-io/balena/compare/832f5551127dd8e1e82fa082bea97fc4db81c3ce...5006321063c1c771809bcb39e74b3575a0db652e)

`maximum` -> `max`
`minimum` -> `min`
`exclusiveMaximum` -> `exclusiveMax`
`exclusiveMinimum` -> `exclusiveMin`