### PR TITLE
Add support for enums on integers

### DIFF
--- a/src/dsl/schema/deserialization.rs
+++ b/src/dsl/schema/deserialization.rs
@@ -147,7 +147,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/src/dsl/schema/object_types/bounds/deserialization.rs
+++ b/src/dsl/schema/object_types/bounds/deserialization.rs
@@ -4,13 +4,12 @@ use serde::de::Error;
 use serde_yaml::Mapping;
 use serde_yaml::Value;
 
-use crate::dsl::schema::Annotations;
 use crate::dsl::schema::deserialization::deserialize_schema;
 use crate::dsl::schema::object_types::bounds::ArrayItemObjectBounds;
 use crate::dsl::schema::object_types::bounds::ArrayObjectBounds;
 use crate::dsl::schema::object_types::bounds::ArrayUniqueItemBound;
 use crate::dsl::schema::object_types::bounds::BooleanObjectBounds;
-use crate::dsl::schema::object_types::bounds::EnumerationValue;
+use crate::dsl::schema::object_types::bounds::enums::deserialize_enumeration;
 use crate::dsl::schema::object_types::bounds::IntegerBound;
 use crate::dsl::schema::object_types::bounds::IntegerObjectBounds;
 use crate::dsl::schema::object_types::bounds::StringLength;
@@ -45,29 +44,6 @@ where
     };
 
     Ok(result)
-}
-
-fn deserialize_enumeration<E>(mapping: &Mapping) -> Result<Option<Vec<EnumerationValue>>, E>
-where
-    E: Error,
-{
-    let enumeration_values = deserialize_enumeration_values(&mapping)?;
-    let constant_value = deserialize_constant_value(&mapping)?.map(|value| vec![value]);
-    if (enumeration_values.is_some()) && constant_value.is_some() {
-        return Err(Error::custom("cannot have both enum and const defined"));
-    }
-    let possible_values = enumeration_values.or(constant_value);
-    let possible_values = possible_values.map(|mut list| {
-        list.iter_mut()
-            .map(|value| {
-                if value.annotations.title.is_none() {
-                    value.annotations.title = value.value.as_str().map(|s| s.to_string());
-                }
-                value.clone()
-            })
-            .collect()
-    });
-    Ok(possible_values)
 }
 
 pub fn deserialize_length_bounds<E>(mapping: &Mapping) -> Result<Option<StringObjectBounds>, E>
@@ -198,30 +174,6 @@ where
     }
 }
 
-fn deserialize_enumeration_values<E>(mapping: &Mapping) -> Result<Option<Vec<EnumerationValue>>, E>
-where
-    E: Error,
-{
-    let enum_key = Value::from("enum");
-    match mapping.get(&enum_key) {
-        Some(mapping) => match mapping {
-            Value::Sequence(sequence) => {
-                let result = sequence
-                    .iter()
-                    .map(|definition| enumeration_definition_to_enumeration_value(definition))
-                    .collect::<Result<Vec<EnumerationValue>, E>>()?;
-                if !result.is_empty() {
-                    Ok(Some(result))
-                } else {
-                    Ok(None)
-                }
-            }
-            _ => Err(Error::custom(format!("enum `{:#?}` is not a sequence", mapping))),
-        },
-        None => Ok(None),
-    }
-}
-
 fn deserialize_pattern<E>(mapping: &Mapping) -> Result<Option<Regex>, E>
 where
     E: Error,
@@ -238,71 +190,6 @@ where
         },
         None => Ok(None),
     }
-}
-
-fn deserialize_constant_value<E>(mapping: &Mapping) -> Result<Option<EnumerationValue>, E>
-where
-    E: Error,
-{
-    let constant_key = Value::from("const");
-    let value = mapping.get(&constant_key).map_or(Ok(None), |value| {
-        serde_yaml::from_value(value.clone())
-            .map_err(|e| Error::custom(format!("cannot deserialize constant specifier: {:?} - {}", value, e)))
-    })?;
-    let annotations = Annotations {
-        title: None,
-        help: None,
-        warning: None,
-        description: None,
-    };
-    match value {
-        None => Ok(None),
-        Some(value) => Ok(Some(EnumerationValue { value, annotations })),
-    }
-}
-
-fn enumeration_definition_to_enumeration_value<E>(definition: &Value) -> Result<EnumerationValue, E>
-where
-    E: Error,
-{
-    match definition {
-        Value::String(string) => Ok(string.as_str().into()),
-        Value::Mapping(mapping) => Ok(mapping_to_enumeration_value(mapping)?),
-        _ => Err(Error::custom(format!("no idea how to deserialize {:#?}", definition))),
-    }
-}
-
-fn mapping_to_enumeration_value<E>(mapping: &Mapping) -> Result<EnumerationValue, E>
-where
-    E: Error,
-{
-    let value = mapping
-        .get(&Value::from("value"))
-        .ok_or_else(|| Error::custom("when the enumeration is a mapping - expected 'value' to be present"))?;
-
-    let title = mapping.get(&Value::from("title")).map(|value| match value {
-        Value::String(string) => Ok(string),
-        _ => Err(Error::custom(format!("enum title `{:#?}` must be a string", value))),
-    });
-
-    let title = match title {
-        None => None,
-        Some(result) => match result {
-            Ok(value) => Some(value.to_string()),
-            Err(e) => return Err(e),
-        },
-    };
-
-    let annotations = Annotations {
-        title,
-        help: None,
-        warning: None,
-        description: None,
-    };
-    Ok(EnumerationValue {
-        annotations,
-        value: value.clone(),
-    })
 }
 
 fn deserialize_integer_bound<E>(name: &str, mapping: &Mapping) -> Result<Option<IntegerBound>, E>

--- a/src/dsl/schema/object_types/bounds/enums.rs
+++ b/src/dsl/schema/object_types/bounds/enums.rs
@@ -1,0 +1,118 @@
+use serde::de::Error;
+use serde_yaml::Mapping;
+use serde_yaml::Value;
+
+use crate::dsl::schema::Annotations;
+use crate::dsl::schema::object_types::bounds::EnumerationValue;
+
+pub fn deserialize_enumeration<E>(mapping: &Mapping) -> Result<Option<Vec<EnumerationValue>>, E>
+where
+    E: Error,
+{
+    let enumeration_values = deserialize_enumeration_values(&mapping)?;
+    let constant_value = deserialize_constant_value(&mapping)?.map(|value| vec![value]);
+    if (enumeration_values.is_some()) && constant_value.is_some() {
+        return Err(Error::custom("cannot have both enum and const defined"));
+    }
+    let possible_values = enumeration_values.or(constant_value);
+    let possible_values = possible_values.map(|mut list| {
+        list.iter_mut()
+            .map(|value| {
+                if value.annotations.title.is_none() {
+                    value.annotations.title = value.value.as_str().map(|s| s.to_string());
+                }
+                value.clone()
+            })
+            .collect()
+    });
+    Ok(possible_values)
+}
+
+fn deserialize_enumeration_values<E>(mapping: &Mapping) -> Result<Option<Vec<EnumerationValue>>, E>
+where
+    E: Error,
+{
+    let enum_key = Value::from("enum");
+    match mapping.get(&enum_key) {
+        Some(mapping) => match mapping {
+            Value::Sequence(sequence) => {
+                let result = sequence
+                    .iter()
+                    .map(|definition| enumeration_definition_to_enumeration_value(definition))
+                    .collect::<Result<Vec<EnumerationValue>, E>>()?;
+                if !result.is_empty() {
+                    Ok(Some(result))
+                } else {
+                    Ok(None)
+                }
+            }
+            _ => Err(Error::custom(format!("enum `{:#?}` is not a sequence", mapping))),
+        },
+        None => Ok(None),
+    }
+}
+
+fn enumeration_definition_to_enumeration_value<E>(definition: &Value) -> Result<EnumerationValue, E>
+where
+    E: Error,
+{
+    match definition {
+        Value::String(string) => Ok(string.as_str().into()),
+        Value::Mapping(mapping) => Ok(mapping_to_enumeration_value(mapping)?),
+        _ => Err(Error::custom(format!("no idea how to deserialize {:#?}", definition))),
+    }
+}
+
+fn mapping_to_enumeration_value<E>(mapping: &Mapping) -> Result<EnumerationValue, E>
+where
+    E: Error,
+{
+    let value = mapping
+        .get(&Value::from("value"))
+        .ok_or_else(|| Error::custom("when the enumeration is a mapping - expected 'value' to be present"))?;
+
+    let title = mapping.get(&Value::from("title")).map(|value| match value {
+        Value::String(string) => Ok(string),
+        _ => Err(Error::custom(format!("enum title `{:#?}` must be a string", value))),
+    });
+
+    let title = match title {
+        None => None,
+        Some(result) => match result {
+            Ok(value) => Some(value.to_string()),
+            Err(e) => return Err(e),
+        },
+    };
+
+    let annotations = Annotations {
+        title,
+        help: None,
+        warning: None,
+        description: None,
+    };
+    Ok(EnumerationValue {
+        annotations,
+        value: value.clone(),
+    })
+}
+
+fn deserialize_constant_value<E>(mapping: &Mapping) -> Result<Option<EnumerationValue>, E>
+where
+    E: Error,
+{
+    let constant_key = Value::from("const");
+    let value = mapping.get(&constant_key).map_or(Ok(None), |value| {
+        serde_yaml::from_value(value.clone())
+            .map_err(|e| Error::custom(format!("cannot deserialize constant specifier: {:?} - {}", value, e)))
+    })?;
+    let annotations = Annotations {
+        title: None,
+        help: None,
+        warning: None,
+        description: None,
+    };
+    match value {
+        None => Ok(None),
+        Some(value) => Ok(Some(EnumerationValue { value, annotations })),
+    }
+}

--- a/src/dsl/schema/object_types/bounds/mod.rs
+++ b/src/dsl/schema/object_types/bounds/mod.rs
@@ -8,18 +8,24 @@ use crate::dsl::schema::Schema;
 pub mod deserialization;
 mod enums;
 
-// TODO: impl serialize separately, to not have serialization code in the `dsl` module
-#[derive(Clone, Debug, Serialize)]
-pub enum IntegerBound {
-    Inclusive(i64),
-    Exclusive(i64),
+#[derive(Clone, Debug)]
+pub enum StringObjectBounds {
+    List(Vec<EnumerationValue>),
+    Pattern(Regex),
+    Length(StringLength),
 }
 
 #[derive(Clone, Debug)]
-pub struct IntegerObjectBounds {
+pub struct IntegerValueConditionObjectBounds {
     pub minimum: Option<IntegerBound>,
     pub maximum: Option<IntegerBound>,
     pub multiple_of: Option<i64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum IntegerObjectBounds {
+    Conditions(IntegerValueConditionObjectBounds),
+    List(Vec<EnumerationValue>),
 }
 
 #[derive(Clone, Debug)]
@@ -42,6 +48,13 @@ pub enum ArrayItemObjectBounds {
     AnyItems(Vec<Schema>),
 }
 
+// TODO: impl serialize separately, to not have serialization code in the `dsl` module
+#[derive(Clone, Debug, Serialize)]
+pub enum IntegerBound {
+    Inclusive(i64),
+    Exclusive(i64),
+}
+
 impl IntegerBound {
     pub fn inner(&self) -> &i64 {
         match self {
@@ -55,13 +68,6 @@ impl IntegerBound {
 pub struct StringLength {
     pub minimum: Option<i64>,
     pub maximum: Option<i64>,
-}
-
-#[derive(Clone, Debug)]
-pub enum StringObjectBounds {
-    PossibleValues(Vec<EnumerationValue>),
-    Pattern(Regex),
-    Length(StringLength),
 }
 
 #[derive(Clone, Debug)]

--- a/src/dsl/schema/object_types/bounds/mod.rs
+++ b/src/dsl/schema/object_types/bounds/mod.rs
@@ -6,6 +6,7 @@ use crate::dsl::schema::Annotations;
 use crate::dsl::schema::Schema;
 
 pub mod deserialization;
+mod enums;
 
 // TODO: impl serialize separately, to not have serialization code in the `dsl` module
 #[derive(Clone, Debug, Serialize)]

--- a/src/dsl/schema/object_types/bounds/mod.rs
+++ b/src/dsl/schema/object_types/bounds/mod.rs
@@ -71,7 +71,7 @@ pub enum BooleanObjectBounds {
 #[derive(Clone, Debug)]
 pub struct EnumerationValue {
     pub annotations: Annotations,
-    pub value: String,
+    pub value: serde_yaml::Value,
 }
 
 impl From<&str> for EnumerationValue {
@@ -84,7 +84,7 @@ impl From<&str> for EnumerationValue {
             description: None,
         };
         EnumerationValue {
-            value: value.clone(),
+            value: value.into(),
             annotations,
         }
     }

--- a/src/output/serialization/object_types.rs
+++ b/src/output/serialization/object_types.rs
@@ -154,11 +154,15 @@ where
     S: SerializeMap<Ok = O, Error = E>,
 {
     if let Some(bounds) = bounds {
-        serialize_integer_bound("maximum", &bounds.maximum, map)?;
-        serialize_integer_bound("minimum", &bounds.minimum, map)?;
-
-        if let Some(multiple_of) = bounds.multiple_of {
-            map.serialize_entry("multipleOf", &multiple_of)?;
+        match bounds {
+            IntegerObjectBounds::Conditions(conditions) => {
+                serialize_integer_bound("maximum", &conditions.maximum, map)?;
+                serialize_integer_bound("minimum", &conditions.minimum, map)?;
+                if let Some(multiple_of) = conditions.multiple_of {
+                    map.serialize_entry("multipleOf", &multiple_of)?;
+                }
+            }
+            IntegerObjectBounds::List(list) => serialize_enum_bounds(list, map)?,
         }
     }
     Ok(())
@@ -170,15 +174,22 @@ where
     S: SerializeMap<Ok = O, Error = E>,
 {
     match string_bounds {
-        StringObjectBounds::PossibleValues(values) => {
-            if values.len() == 1 {
-                serialize_singular_constant_value(&values[0], map)?;
-            } else {
-                serialize_multiple_enum_values(&values, map)?;
-            }
-        }
+        StringObjectBounds::List(values) => serialize_enum_bounds(values, map)?,
         StringObjectBounds::Pattern(pattern) => map.serialize_entry("pattern", pattern.as_str())?,
         StringObjectBounds::Length(length) => serialize_length_bounds(length, map)?,
+    }
+    Ok(())
+}
+
+fn serialize_enum_bounds<O, E, S>(values: &[EnumerationValue], map: &mut S) -> Result<(), E>
+where
+    E: Error,
+    S: SerializeMap<Ok = O, Error = E>,
+{
+    if values.len() == 1 {
+        serialize_singular_constant_value(&values[0], map)?;
+    } else {
+        serialize_multiple_enum_values(&values, map)?;
     }
     Ok(())
 }

--- a/src/output/serialization/object_types.rs
+++ b/src/output/serialization/object_types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::string::ToString;
 
 use heck::MixedCase;
@@ -16,7 +17,6 @@ use crate::dsl::schema::object_types::bounds::IntegerObjectBounds;
 use crate::dsl::schema::object_types::bounds::StringLength;
 use crate::dsl::schema::object_types::bounds::StringObjectBounds;
 use crate::dsl::schema::object_types::RawObjectType;
-use std::collections::HashMap;
 
 impl Serialize for EnumerationValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/tests/data/enums/simple/input-schema.yml
+++ b/tests/data/enums/simple/input-schema.yml
@@ -1,9 +1,9 @@
 version: 1
 title: Enum test
 properties:
-- shortOne:
-    type: string
-    enum:
-    - fincm3
-    - raspberrypi3
-    - raspberrypi2
+  - shortOne:
+      type: string
+      enum:
+        - fincm3
+        - raspberrypi3
+        - raspberrypi2

--- a/tests/data/enums/value/input-schema.yml
+++ b/tests/data/enums/value/input-schema.yml
@@ -1,9 +1,17 @@
 version: 1
 title: Enum test
 properties:
-- mediumOne:
-    type: string
-    enum:
-    - value: fincm3
-    - value: raspberrypi3
-    - value: raspberrypi2
+  - mediumOne:
+      type: string
+      enum:
+        - value: fincm3
+        - value: raspberrypi3
+        - value: raspberrypi2
+
+  - cores:
+      type: integer
+      enum:
+        - value: 1
+          title: Single
+        - value: 4
+          title: Quad

--- a/tests/data/enums/value/output-json-schema.json
+++ b/tests/data/enums/value/output-json-schema.json
@@ -3,10 +3,12 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "$$order": [
-        "mediumOne"
+        "mediumOne",
+        "cores"
     ],
     "required": [
-        "mediumOne"
+        "mediumOne",
+        "cores"
     ],
     "title": "Enum test",
     "properties": {
@@ -29,6 +31,23 @@
                     "title": "raspberrypi2",
                     "enum": [
                         "raspberrypi2"
+                    ]
+                }
+            ]
+        },
+        "cores": {
+            "type": "integer",
+            "oneOf": [
+                {
+                    "title": "Single",
+                    "enum": [
+                        1
+                    ]
+                },
+                {
+                    "title": "Quad",
+                    "enum": [
+                        4
                     ]
                 }
             ]


### PR DESCRIPTION
As per #15 and #49 - on master we only support `enum` keyword on `string` type - this PR makes the enum support be more generic and applies it to the `integer` type as well. 

Not adding support for `enum` on any other base type for now - let's see what is needed. E.g. not sure if we need/want support for enums on `boolean` etc. If needed - adding support for more types should be literally 2 lines of code per type, one for deserialization and one for serialization.

Extracted out `enum` module and made `EnumerationValue` store `Value` instead of `String` to be able to abstract over any type that can be enumerated.

Fixes #49 