### PR TITLE
Fix port type to be integer on JSONSchema side

### DIFF
--- a/src/output/serialization/object_types.rs
+++ b/src/output/serialization/object_types.rs
@@ -78,7 +78,7 @@ pub fn object_type_name(object_type: &RawObjectType) -> &str {
         RawObjectType::Password(_) => "string",
         RawObjectType::Integer(_) => "integer",
         RawObjectType::Number(_) => "number",
-        RawObjectType::Port(_) => "number",
+        RawObjectType::Port(_) => "integer",
         RawObjectType::Array(_) => "array",
 
         RawObjectType::Hostname => "string",

--- a/tests/data/numbers/default/output-json-schema.json
+++ b/tests/data/numbers/default/output-json-schema.json
@@ -23,7 +23,7 @@
             "default": 3
         },
         "port": {
-            "type": "number",
+            "type": "integer",
             "minimum": 0,
             "maximum": 65535,
             "default": 80

--- a/tests/data/numbers/port/output-json-schema.json
+++ b/tests/data/numbers/port/output-json-schema.json
@@ -13,12 +13,12 @@
     ],
     "properties": {
         "port": {
-            "type": "number",
+            "type": "integer",
             "minimum": 0,
             "maximum": 65535
         },
         "customport": {
-            "type": "number",
+            "type": "integer",
             "minimum": 1024,
             "maximum": 2048
         }


### PR DESCRIPTION
`port` was producing `number` instead of `integer` - fixed that.