### PR TITLE
Emit proper `anyOf` for compound types

### DIFF
--- a/tests/data/schema/multiple_types/input-schema.yml
+++ b/tests/data/schema/multiple_types/input-schema.yml
@@ -3,3 +3,9 @@ title: Multiple types (one property)
 properties:
 - age:
     type: [integer, string]
+- distance:
+    type: [number, string]
+- hostname:
+    type: [string, hostname]
+- address:
+    type: [ipv4, ipv6]

--- a/tests/data/schema/multiple_types/output-json-schema.json
+++ b/tests/data/schema/multiple_types/output-json-schema.json
@@ -3,17 +3,60 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "$$order": [
-        "age"
+        "age",
+        "distance",
+        "hostname",
+        "address"
     ],
     "required": [
-        "age"
+        "age",
+        "distance",
+        "hostname",
+        "address"
     ],
     "title": "Multiple types (one property)",
     "properties": {
         "age": {
-            "type": [
-                "integer",
-                "string"
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "distance": {
+            "anyOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "hostname": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "string",
+                    "format": "hostname"
+                }
+            ]
+        },
+        "address": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "format": "ipv4"
+                },
+                {
+                    "type": "string",
+                    "format": "ipv6"
+                }
             ]
         }
     }


### PR DESCRIPTION
As per discussion with Lucian - decided to emit 
```
"properties": {
        "age": {
            "anyOf": [
                {
                    "type": "string"
                },
                {
                    "type": "integer"
                }
            ]
        }
}
```

instead of 
```
 "anyOf": [
        {
            "properties": {
                "age": {
                    "type": "string"
                }
            }
        },
        {
            "properties": {
                "age": {
                    "type": "integer"
                }
            }
        }
]
```

Both are valid JSONSchema but the first one allows for less misinterpretation on the user side and was also easier to emit.

See #62 and #15 for context. 