### PR TITLE
Move to Rust stable

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
-beta
+stable
 


### PR DESCRIPTION
As the issues we had previously rode the trains and the fixes are in
1.32 now - we can switch to stable.

Fixes #42 

Change-type: patch