### PR TITLE
Add support for array annotations

### DIFF
--- a/src/dsl/schema/mod.rs
+++ b/src/dsl/schema/mod.rs
@@ -64,6 +64,9 @@ pub struct Annotations {
     pub warning: Option<String>,
     pub description: Option<String>,
     pub widget: Option<Widget>,
+    pub orderable: Option<bool>,
+    pub addable: Option<bool>,
+    pub removable: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -149,5 +152,12 @@ impl SchemaList {
                 }
             })
             .collect()
+    }
+}
+
+impl Annotations {
+    pub fn with_title_option(title: Option<String>) -> Annotations {
+        let default = Annotations::default();
+        Annotations { title, ..default }
     }
 }

--- a/src/dsl/schema/object_types/bounds/enums.rs
+++ b/src/dsl/schema/object_types/bounds/enums.rs
@@ -83,14 +83,7 @@ where
             Err(e) => return Err(e),
         },
     };
-
-    let annotations = Annotations {
-        title,
-        help: None,
-        warning: None,
-        description: None,
-        widget: None,
-    };
+    let annotations = Annotations::with_title_option(title);
     Ok(EnumerationValue {
         annotations,
         value: value.clone(),
@@ -106,15 +99,11 @@ where
         serde_yaml::from_value(value.clone())
             .map_err(|e| Error::custom(format!("cannot deserialize constant specifier: {:?} - {}", value, e)))
     })?;
-    let annotations = Annotations {
-        title: None,
-        help: None,
-        warning: None,
-        description: None,
-        widget: None,
-    };
     match value {
         None => Ok(None),
-        Some(value) => Ok(Some(EnumerationValue { value, annotations })),
+        Some(value) => Ok(Some(EnumerationValue {
+            value,
+            annotations: Annotations::default(),
+        })),
     }
 }

--- a/src/dsl/schema/object_types/bounds/mod.rs
+++ b/src/dsl/schema/object_types/bounds/mod.rs
@@ -115,13 +115,7 @@ pub struct EnumerationValue {
 impl From<&str> for EnumerationValue {
     fn from(value: &str) -> Self {
         let value = value.to_string();
-        let annotations = Annotations {
-            title: Some(value.clone()),
-            help: None,
-            warning: None,
-            description: None,
-            widget: None,
-        };
+        let annotations = Annotations::with_title_option(Some(value.clone()));
         EnumerationValue {
             value: value.into(),
             annotations,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -33,6 +33,13 @@ impl UiObject {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct UiOptions {
+    removable: bool,
+    addable: bool,
+    orderable: bool,
+}
+
 #[derive(Clone, Debug, Serialize)]
 struct UiObjectProperty {
     #[serde(rename = "ui:help", skip_serializing_if = "Option::is_none")]
@@ -47,6 +54,9 @@ struct UiObjectProperty {
     properties: Option<UiObject>,
     #[serde(flatten)]
     keys: Option<KeysSchema>,
+
+    #[serde(rename = "ui:options", skip_serializing_if = "Option::is_none")]
+    ui_options: Option<UiOptions>,
 }
 
 impl UiObjectProperty {
@@ -57,6 +67,8 @@ impl UiObjectProperty {
             && self.description.is_none()
             && self.widget.is_none()
             && self.properties.is_none()
+            && self.keys.is_none()
+            && self.ui_options.is_none()
     }
 }
 
@@ -65,6 +77,16 @@ impl UiObjectRoot {
         match &self.0 {
             None => true,
             Some(property) => property.is_empty(),
+        }
+    }
+}
+
+impl Default for UiOptions {
+    fn default() -> Self {
+        UiOptions {
+            removable: true,
+            addable: true,
+            orderable: true,
         }
     }
 }

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -10,6 +10,7 @@ use crate::output::UiObjectRoot;
 use serde::Serialize;
 use serde::Serializer;
 use crate::dsl::schema::KeysSchema;
+use crate::output::UiOptions;
 
 impl From<DocumentRoot> for UiObjectRoot {
     fn from(schema: DocumentRoot) -> UiObjectRoot {
@@ -39,13 +40,27 @@ impl From<SchemaList> for UiObject {
 
 impl From<Schema> for UiObjectProperty {
     fn from(schema: Schema) -> Self {
-        let help = schema.annotations.help;
-        let warning = schema.annotations.warning;
-        let description = schema.annotations.description;
-        let widget = schema.annotations.widget;
+        let annotations = schema.annotations.clone();
+        let help = annotations.help;
+        let warning = annotations.warning;
+        let description = annotations.description;
+        let widget = annotations.widget;
         let keys_values = schema.dynamic.map(|keys_values| keys_values.keys);
 
         let children = schema.children.map(|children| children.into());
+        let default_ui_options = UiOptions::default();
+
+        let ui_options = UiOptions {
+            removable: annotations.removable.unwrap_or(default_ui_options.removable),
+            addable: annotations.addable.unwrap_or(default_ui_options.addable),
+            orderable: annotations.orderable.unwrap_or(default_ui_options.orderable),
+        };
+
+        let ui_options = if ui_options == default_ui_options {
+            None
+        } else {
+            Some(ui_options)
+        };
 
         UiObjectProperty {
             help,
@@ -54,6 +69,7 @@ impl From<Schema> for UiObjectProperty {
             widget,
             properties: children,
             keys: keys_values,
+            ui_options,
         }
     }
 }

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -40,7 +40,7 @@ impl From<SchemaList> for UiObject {
 
 impl From<Schema> for UiObjectProperty {
     fn from(schema: Schema) -> Self {
-        let annotations = schema.annotations.clone();
+        let annotations = schema.annotations;
         let help = annotations.help;
         let warning = annotations.warning;
         let description = annotations.description;

--- a/tests/data/annotations/array/input-schema.yml
+++ b/tests/data/annotations/array/input-schema.yml
@@ -1,15 +1,25 @@
 version: 1
 title: Array annotations
+definitions:
+  items: &ITEMS
+    properties:
+      - someproperty:
+          type: string
+
 properties:
   - nonorderable:
       type: array
       orderable: false
+      items: *ITEMS
   - nonaddable:
       type: array
       addable: false
+      items: *ITEMS
   - nonremovable:
       type: array
       removable: false
+      items: *ITEMS
   - default:
       type: array
+      items: *ITEMS
       title: orderable, addable and removable should default to true and then default UiOptions should not be emitted

--- a/tests/data/annotations/array/input-schema.yml
+++ b/tests/data/annotations/array/input-schema.yml
@@ -1,0 +1,15 @@
+version: 1
+title: Array annotations
+properties:
+  - nonorderable:
+      type: array
+      orderable: false
+  - nonaddable:
+      type: array
+      addable: false
+  - nonremovable:
+      type: array
+      removable: false
+  - default:
+      type: array
+      title: orderable, addable and removable should default to true

--- a/tests/data/annotations/array/input-schema.yml
+++ b/tests/data/annotations/array/input-schema.yml
@@ -12,4 +12,4 @@ properties:
       removable: false
   - default:
       type: array
-      title: orderable, addable and removable should default to true
+      title: orderable, addable and removable should default to true and then default UiOptions should not be emitted

--- a/tests/data/annotations/array/output-json-schema.json
+++ b/tests/data/annotations/array/output-json-schema.json
@@ -18,16 +18,76 @@
     ],
     "properties": {
         "nonorderable": {
-            "type": "array"
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "someproperty"
+                ],
+                "$$order": [
+                    "someproperty"
+                ],
+                "properties": {
+                    "someproperty": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "nonaddable": {
-            "type": "array"
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "someproperty"
+                ],
+                "$$order": [
+                    "someproperty"
+                ],
+                "properties": {
+                    "someproperty": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "nonremovable": {
-            "type": "array"
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "someproperty"
+                ],
+                "$$order": [
+                    "someproperty"
+                ],
+                "properties": {
+                    "someproperty": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "default": {
             "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "someproperty"
+                ],
+                "$$order": [
+                    "someproperty"
+                ],
+                "properties": {
+                    "someproperty": {
+                        "type": "string"
+                    }
+                }
+            },
             "title": "orderable, addable and removable should default to true and then default UiOptions should not be emitted"
         }
     }

--- a/tests/data/annotations/array/output-json-schema.json
+++ b/tests/data/annotations/array/output-json-schema.json
@@ -1,0 +1,34 @@
+{
+    "$$version": 1,
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "title": "Array annotations",
+    "$$order": [
+        "nonorderable",
+        "nonaddable",
+        "nonremovable",
+        "default"
+    ],
+    "required": [
+        "nonorderable",
+        "nonaddable",
+        "nonremovable",
+        "default"
+    ],
+    "properties": {
+        "nonorderable": {
+            "type": "array"
+        },
+        "nonaddable": {
+            "type": "array"
+        },
+        "nonremovable": {
+            "type": "array"
+        },
+        "default": {
+            "type": "array",
+            "title": "orderable, addable and removable should default to true"
+        }
+    }
+}

--- a/tests/data/annotations/array/output-json-schema.json
+++ b/tests/data/annotations/array/output-json-schema.json
@@ -28,7 +28,7 @@
         },
         "default": {
             "type": "array",
-            "title": "orderable, addable and removable should default to true"
+            "title": "orderable, addable and removable should default to true and then default UiOptions should not be emitted"
         }
     }
 }

--- a/tests/data/annotations/array/output-uiobject.json
+++ b/tests/data/annotations/array/output-uiobject.json
@@ -1,24 +1,23 @@
 {
     "nonorderable": {
         "ui:options": {
+            "addable": true,
+            "removable": true,
             "orderable": false
         }
     },
     "nonaddable": {
         "ui:options": {
-            "addable": false
+            "addable": false,
+            "removable": true,
+            "orderable": true
         }
     },
     "nonremovable": {
         "ui:options": {
-            "removable": false
-        }
-    },
-    "default": {
-        "ui:options": {
-            "orderable": true,
+            "removable": false,
             "addable": true,
-            "removable": true
+            "orderable": true
         }
     }
 }

--- a/tests/data/annotations/array/output-uiobject.json
+++ b/tests/data/annotations/array/output-uiobject.json
@@ -1,0 +1,24 @@
+{
+    "nonorderable": {
+        "ui:options": {
+            "orderable": false
+        }
+    },
+    "nonaddable": {
+        "ui:options": {
+            "addable": false
+        }
+    },
+    "nonremovable": {
+        "ui:options": {
+            "removable": false
+        }
+    },
+    "default": {
+        "ui:options": {
+            "orderable": true,
+            "addable": true,
+            "removable": true
+        }
+    }
+}


### PR DESCRIPTION
This PR brings in naive support for pass-through array annotations (`addable`, `removable` and `orderable`)
See [rjsf](https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJub25vcmRlcmFibGUiOlt7fSx7fV0sIm5vbnJlbW92YWJsZSI6W3t9LHt9XSwiZGVmYXVsdCI6W3t9LHt9XX0sInNjaGVtYSI6eyIkJHZlcnNpb24iOjEsIiRzY2hlbWEiOiJodHRwOi8vanNvbi1zY2hlbWEub3JnL2RyYWZ0LTA0L3NjaGVtYSMiLCJ0eXBlIjoib2JqZWN0IiwiYWRkaXRpb25hbFByb3BlcnRpZXMiOmZhbHNlLCJ0aXRsZSI6IkFycmF5IGFubm90YXRpb25zIiwiJCRvcmRlciI6WyJub25vcmRlcmFibGUiLCJub25hZGRhYmxlIiwibm9ucmVtb3ZhYmxlIiwiZGVmYXVsdCJdLCJyZXF1aXJlZCI6WyJub25vcmRlcmFibGUiLCJub25hZGRhYmxlIiwibm9ucmVtb3ZhYmxlIiwiZGVmYXVsdCJdLCJwcm9wZXJ0aWVzIjp7Im5vbm9yZGVyYWJsZSI6eyJ0eXBlIjoiYXJyYXkiLCJpdGVtcyI6eyJ0eXBlIjoib2JqZWN0IiwiYWRkaXRpb25hbFByb3BlcnRpZXMiOmZhbHNlLCJyZXF1aXJlZCI6WyJzb21lcHJvcGVydHkiXSwiJCRvcmRlciI6WyJzb21lcHJvcGVydHkiXSwicHJvcGVydGllcyI6eyJzb21lcHJvcGVydHkiOnsidHlwZSI6InN0cmluZyJ9fX19LCJub25hZGRhYmxlIjp7InR5cGUiOiJhcnJheSIsIml0ZW1zIjp7InR5cGUiOiJvYmplY3QiLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInJlcXVpcmVkIjpbInNvbWVwcm9wZXJ0eSJdLCIkJG9yZGVyIjpbInNvbWVwcm9wZXJ0eSJdLCJwcm9wZXJ0aWVzIjp7InNvbWVwcm9wZXJ0eSI6eyJ0eXBlIjoic3RyaW5nIn19fX0sIm5vbnJlbW92YWJsZSI6eyJ0eXBlIjoiYXJyYXkiLCJpdGVtcyI6eyJ0eXBlIjoib2JqZWN0IiwiYWRkaXRpb25hbFByb3BlcnRpZXMiOmZhbHNlLCJyZXF1aXJlZCI6WyJzb21lcHJvcGVydHkiXSwiJCRvcmRlciI6WyJzb21lcHJvcGVydHkiXSwicHJvcGVydGllcyI6eyJzb21lcHJvcGVydHkiOnsidHlwZSI6InN0cmluZyJ9fX19LCJkZWZhdWx0Ijp7InR5cGUiOiJhcnJheSIsIml0ZW1zIjp7InR5cGUiOiJvYmplY3QiLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInJlcXVpcmVkIjpbInNvbWVwcm9wZXJ0eSJdLCIkJG9yZGVyIjpbInNvbWVwcm9wZXJ0eSJdLCJwcm9wZXJ0aWVzIjp7InNvbWVwcm9wZXJ0eSI6eyJ0eXBlIjoic3RyaW5nIn19fSwidGl0bGUiOiJvcmRlcmFibGUsIGFkZGFibGUgYW5kIHJlbW92YWJsZSBzaG91bGQgZGVmYXVsdCB0byB0cnVlIGFuZCB0aGVuIGRlZmF1bHQgVWlPcHRpb25zIHNob3VsZCBub3QgYmUgZW1pdHRlZCJ9fX0sInVpU2NoZW1hIjp7Im5vbm9yZGVyYWJsZSI6eyJ1aTpvcHRpb25zIjp7ImFkZGFibGUiOnRydWUsInJlbW92YWJsZSI6dHJ1ZSwib3JkZXJhYmxlIjpmYWxzZX19LCJub25hZGRhYmxlIjp7InVpOm9wdGlvbnMiOnsiYWRkYWJsZSI6ZmFsc2UsInJlbW92YWJsZSI6dHJ1ZSwib3JkZXJhYmxlIjp0cnVlfX0sIm5vbnJlbW92YWJsZSI6eyJ1aTpvcHRpb25zIjp7InJlbW92YWJsZSI6ZmFsc2UsImFkZGFibGUiOnRydWUsIm9yZGVyYWJsZSI6dHJ1ZX19fX0=) playground for rendering

As this is just a passthrough right now - it is possible to emit these keywords for types other than arrays - I would like to address this in a separate PR.

See #79 and #15 