### PR TITLE
Emit `ui:order` in addition to `$$order`

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -58,6 +58,8 @@ struct UiObjectProperty {
     ui_options: Option<UiOptions>,
     #[serde(rename = "ui:readonly", skip_serializing_if = "Option::is_none")]
     readonly: Option<bool>,
+    #[serde(rename = "ui:order", skip_serializing_if = "Option::is_none")]
+    order: Option<Vec<String>>,
 }
 
 impl UiObjectProperty {

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -52,7 +52,9 @@ impl From<Schema> for UiObjectProperty {
 
         let children = schema.children;
         let children_ui_objects = children.clone().map(|children| children.into());
-        let order = children.clone().map(|list| list.all_names().iter().map(|name| name.to_string()).collect());
+        let order = children
+            .clone()
+            .map(|list| list.all_names().iter().map(|name| name.to_string()).collect());
 
         let ui_options = ui_options(&annotations);
 

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -50,10 +50,9 @@ impl From<Schema> for UiObjectProperty {
         let readonly = readonly(&annotations);
         let keys_values = schema.dynamic.map(|keys_values| keys_values.keys);
 
-        let children = schema.children.clone();
-        let children_ui_objects = children.map(|children| children.into());
-        let children = schema.children.clone();
-        let order = children.map(|list| list.all_names().iter().map(|name| name.to_string()).collect());
+        let children = schema.children;
+        let children_ui_objects = children.clone().map(|children| children.into());
+        let order = children.clone().map(|list| list.all_names().iter().map(|name| name.to_string()).collect());
 
         let ui_options = ui_options(&annotations);
 

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -50,7 +50,10 @@ impl From<Schema> for UiObjectProperty {
         let readonly = readonly(&annotations);
         let keys_values = schema.dynamic.map(|keys_values| keys_values.keys);
 
-        let children = schema.children.map(|children| children.into());
+        let children = schema.children.clone();
+        let children_ui_objects = children.map(|children| children.into());
+        let children = schema.children.clone();
+        let order = children.map(|list| list.all_names().iter().map(|name| name.to_string()).collect());
 
         let ui_options = ui_options(&annotations);
 
@@ -60,10 +63,11 @@ impl From<Schema> for UiObjectProperty {
             description,
             placeholder,
             widget,
-            properties: children,
+            properties: children_ui_objects,
             keys: keys_values,
             ui_options,
             readonly,
+            order,
         }
     }
 }

--- a/tests/backlog/_demo/resin_cli/output-uiobject.json
+++ b/tests/backlog/_demo/resin_cli/output-uiobject.json
@@ -1,8 +1,20 @@
 {
     "network": {
-        "ui:collapsible": false
+        "ui:collapsible": false,
+        "ui:order": [
+            "ssid",
+            "passphrase"
+        ]
     },
     "advanced": {
-        "ui:collapsed": true
-    }
+        "ui:collapsed": true,
+        "ui:order": [
+            "hostname",
+            "persistentLogging"
+        ]
+    },
+    "ui:order": [
+        "network",
+        "advanced"
+    ]
 }

--- a/tests/data/_demo/resin_cli_no_ui_object/output-uiobject.json
+++ b/tests/data/_demo/resin_cli_no_ui_object/output-uiobject.json
@@ -1,8 +1,21 @@
 {
-    "advanced": {},
+    "advanced": {
+        "ui:order": [
+            "hostname",
+            "persistentLogging"
+        ]
+    },
     "network": {
         "passphrase": {
             "ui:widget": "password"
-        }
-    }
+        },
+        "ui:order": [
+            "ssid",
+            "passphrase"
+        ]
+    },
+    "ui:order": [
+        "network",
+        "advanced"
+    ]
 }

--- a/tests/data/_demo/resin_technologic_network/output-uiobject.json
+++ b/tests/data/_demo/resin_technologic_network/output-uiobject.json
@@ -2,11 +2,25 @@
     "advanced": {
         "appUpdatePollInterval": {
             "ui:help": "Check for updates every X minutes"
-        }
-    },
-    "network": {
+        },
+        "ui:order": [
+            "appUpdatePollInterval"
+        ]
     },
     "board": {
+        "ui:order": [
+            "cores"
+        ],
         "ui:warning": "Please make sure to select the correct number of CPU Cores for your device.\n**Failing to do so will brick your device**."
-    }
+    },
+    "network": {
+        "ui:order": [
+            "networks"
+        ]
+    },
+    "ui:order": [
+        "board",
+        "network",
+        "advanced"
+    ]
 }

--- a/tests/data/annotations/array/output-uiobject.json
+++ b/tests/data/annotations/array/output-uiobject.json
@@ -1,23 +1,29 @@
 {
-    "nonorderable": {
-        "ui:options": {
-            "addable": true,
-            "removable": true,
-            "orderable": false
-        }
-    },
     "nonaddable": {
         "ui:options": {
             "addable": false,
-            "removable": true,
-            "orderable": true
+            "orderable": true,
+            "removable": true
+        }
+    },
+    "nonorderable": {
+        "ui:options": {
+            "addable": true,
+            "orderable": false,
+            "removable": true
         }
     },
     "nonremovable": {
         "ui:options": {
-            "removable": false,
             "addable": true,
-            "orderable": true
+            "orderable": true,
+            "removable": false
         }
-    }
+    },
+    "ui:order": [
+        "nonorderable",
+        "nonaddable",
+        "nonremovable",
+        "default"
+    ]
 }

--- a/tests/data/annotations/basic/output-uiobject.json
+++ b/tests/data/annotations/basic/output-uiobject.json
@@ -1,23 +1,23 @@
 {
-    "ui:description": "This is top-level description",
-    "ui:help": "Some top-level help",
-    "ui:warning": "OMG top.",
-    "justwarning": {
+    "alltogether": {
+        "ui:description": "Lorem ipsum dolor sit amet",
+        "ui:help": "Hello help",
         "ui:warning": "Warning!"
     },
-    "justhelp": {
-        "ui:help": "Hello help"
+    "hidden": {
+        "ui:widget": "hidden"
     },
     "justdescription": {
         "ui:description": "Lorem ipsum dolor sit amet"
     },
-    "alltogether": {
-        "ui:warning": "Warning!",
-        "ui:help": "Hello help",
-        "ui:description": "Lorem ipsum dolor sit amet"
+    "justhelp": {
+        "ui:help": "Hello help"
     },
-    "hidden": {
-        "ui:widget": "hidden"
+    "justwarning": {
+        "ui:warning": "Warning!"
+    },
+    "nonreadonly": {
+        "ui:readonly": false
     },
     "placeholder": {
         "ui:placeholder": "hello this is placeholder text"
@@ -25,13 +25,27 @@
     "readonly": {
         "ui:readonly": true
     },
-    "nonreadonly": {
-        "ui:readonly": false
-    },
-    "writeonly": {
-        "ui:widget": "password"
-    },
     "text": {
         "ui:widget": "textarea"
+    },
+    "ui:description": "This is top-level description",
+    "ui:help": "Some top-level help",
+    "ui:order": [
+        "justtitle",
+        "justhelp",
+        "justwarning",
+        "justdescription",
+        "alltogether",
+        "hidden",
+        "placeholder",
+        "readonly",
+        "nonreadonly",
+        "writeonly",
+        "nonwriteonly",
+        "text"
+    ],
+    "ui:warning": "OMG top.",
+    "writeonly": {
+        "ui:widget": "password"
     }
 }

--- a/tests/data/annotations/nested/output-uiobject.json
+++ b/tests/data/annotations/nested/output-uiobject.json
@@ -1,10 +1,19 @@
 {
     "top": {
         "middle": {
-            "ui:description": "half way through",
             "bottom": {
                 "ui:help": "you have reached the bottom"
-            }
-        }
-    }
+            },
+            "ui:description": "half way through",
+            "ui:order": [
+                "bottom"
+            ]
+        },
+        "ui:order": [
+            "middle"
+        ]
+    },
+    "ui:order": [
+        "top"
+    ]
 }

--- a/tests/data/arrays/items/output-uiobject.json
+++ b/tests/data/arrays/items/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "wifiNetworks",
+        "mixedNetworks"
+    ]
+}

--- a/tests/data/arrays/minmax/output-uiobject.json
+++ b/tests/data/arrays/minmax/output-uiobject.json
@@ -1,1 +1,5 @@
-{}
+{
+    "ui:order": [
+        "wifiNetworks"
+    ]
+}

--- a/tests/data/arrays/stringlist/output-uiobject.json
+++ b/tests/data/arrays/stringlist/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "namelist",
+        "portlist"
+    ]
+}

--- a/tests/data/arrays/unique/output-uiobject.json
+++ b/tests/data/arrays/unique/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "uniqueWifiNetworks",
+        "uniqueSsidWifiNetworks"
+    ]
+}

--- a/tests/data/enums/constant/output-uiobject.json
+++ b/tests/data/enums/constant/output-uiobject.json
@@ -1,1 +1,12 @@
-{}
+{
+    "ui:order": [
+        "string",
+        "number",
+        "integer",
+        "hostname",
+        "boolean",
+        "port",
+        "date",
+        "email"
+    ]
+}

--- a/tests/data/enums/simple/output-uiobject.json
+++ b/tests/data/enums/simple/output-uiobject.json
@@ -1,1 +1,8 @@
-{}
+{
+    "ui:order": [
+        "string",
+        "boolean",
+        "hostname",
+        "port"
+    ]
+}

--- a/tests/data/enums/title/output-uiobject.json
+++ b/tests/data/enums/title/output-uiobject.json
@@ -1,1 +1,5 @@
-{}
+{
+    "ui:order": [
+        "longOne"
+    ]
+}

--- a/tests/data/enums/value/output-uiobject.json
+++ b/tests/data/enums/value/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "mediumOne",
+        "cores"
+    ]
+}

--- a/tests/data/file/basic/output-uiobject.json
+++ b/tests/data/file/basic/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "profile-picture",
+        "documents"
+    ]
+}

--- a/tests/data/numbers/basic/output-uiobject.json
+++ b/tests/data/numbers/basic/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "number",
+        "integer"
+    ]
+}

--- a/tests/data/numbers/default/output-uiobject.json
+++ b/tests/data/numbers/default/output-uiobject.json
@@ -1,1 +1,7 @@
-{}
+{
+    "ui:order": [
+        "number",
+        "integer",
+        "port"
+    ]
+}

--- a/tests/data/numbers/port/output-uiobject.json
+++ b/tests/data/numbers/port/output-uiobject.json
@@ -1,1 +1,6 @@
-{}
+{
+    "ui:order": [
+        "port",
+        "customport"
+    ]
+}

--- a/tests/data/numbers/validation/output-uiobject.json
+++ b/tests/data/numbers/validation/output-uiobject.json
@@ -1,1 +1,5 @@
-{}
+{
+    "ui:order": [
+        "multiplesOfTen"
+    ]
+}

--- a/tests/data/schema/additional_properties/output-uiobject.json
+++ b/tests/data/schema/additional_properties/output-uiobject.json
@@ -1,5 +1,16 @@
 {
     "property": {
-        "anotherSubproperty": {}
-    }
+        "anotherSubproperty": {
+            "ui:order": [
+                "final"
+            ]
+        },
+        "ui:order": [
+            "subproperty",
+            "anotherSubproperty"
+        ]
+    },
+    "ui:order": [
+        "property"
+    ]
 }

--- a/tests/data/schema/dynamic/output-uiobject.json
+++ b/tests/data/schema/dynamic/output-uiobject.json
@@ -2,6 +2,12 @@
     "extendedRules": {
         "ui:keys": {
             "ui:title": "Priority"
-        }
-    }
+        },
+        "ui:order": [
+            "name"
+        ]
+    },
+    "ui:order": [
+        "extendedRules"
+    ]
 }

--- a/tests/data/schema/formula/output-uiobject.json
+++ b/tests/data/schema/formula/output-uiobject.json
@@ -1,1 +1,8 @@
-{}
+{
+    "ui:order": [
+        "host",
+        "domain",
+        "fqdn",
+        "priority"
+    ]
+}

--- a/tests/data/schema/multiple_properties/output-uiobject.json
+++ b/tests/data/schema/multiple_properties/output-uiobject.json
@@ -8,5 +8,9 @@
         "ui:help": "You should set your machine name.",
         "ui:warning": "Use something useful.",
         "ui:description": "Hostname is a name of your machine."
-    }
+    },
+    "ui:order": [
+        "source_hostname",
+        "destination_hostname"
+    ]
 }

--- a/tests/data/schema/nested_properties/output-uiobject.json
+++ b/tests/data/schema/nested_properties/output-uiobject.json
@@ -1,3 +1,10 @@
 {
-    "top": {}
+    "top": {
+        "ui:order": [
+            "second"
+        ]
+    },
+    "ui:order": [
+        "top"
+    ]
 }

--- a/tests/data/schema/optional_property/output-uiobject.json
+++ b/tests/data/schema/optional_property/output-uiobject.json
@@ -1,7 +1,10 @@
 {
     "hostname": {
+        "ui:description": "Hostname is a name of your machine.",
         "ui:help": "You should set your machine name.",
-        "ui:warning": "Use something useful.",
-        "ui:description": "Hostname is a name of your machine."
-    }
+        "ui:warning": "Use something useful."
+    },
+    "ui:order": [
+        "hostname"
+    ]
 }

--- a/tests/data/schema/single_property/output-uiobject.json
+++ b/tests/data/schema/single_property/output-uiobject.json
@@ -1,7 +1,10 @@
 {
     "hostname": {
+        "ui:description": "Hostname is a name of your machine.",
         "ui:help": "You should set your machine name.",
-        "ui:warning": "Use something useful.",
-        "ui:description": "Hostname is a name of your machine."
-    }
+        "ui:warning": "Use something useful."
+    },
+    "ui:order": [
+        "hostname"
+    ]
 }

--- a/tests/data/strings/passthrough/output-uiobject.json
+++ b/tests/data/strings/passthrough/output-uiobject.json
@@ -1,1 +1,16 @@
-{}
+{
+    "ui:order": [
+        "string",
+        "datetime",
+        "date",
+        "time",
+        "hostname",
+        "email",
+        "ipv4",
+        "ipv6",
+        "uri",
+        "dnsmasq-address",
+        "chrony-address",
+        "iptables-address"
+    ]
+}

--- a/tests/data/strings/validation/output-uiobject.json
+++ b/tests/data/strings/validation/output-uiobject.json
@@ -1,5 +1,10 @@
 {
-    "password":{
+    "password": {
         "ui:widget": "password"
-    }
+    },
+    "ui:order": [
+        "ssid",
+        "password",
+        "hostname"
+    ]
 }

--- a/tests/data/unknown/illegible/output-uiobject.json
+++ b/tests/data/unknown/illegible/output-uiobject.json
@@ -1,5 +1,8 @@
 {
     "property": {
         "ui:widget": "textarea"
-    }
+    },
+    "ui:order": [
+        "property"
+    ]
 }

--- a/tests/test_template
+++ b/tests/test_template
@@ -13,6 +13,11 @@
 
         let (json_schema, ui_object) = Generator::with(input_schema)?.generate();
 
+        if json_schema != expected_json_schema || ui_object != expected_ui_object {{
+            eprintln!("JSONSchema:\n {{}}", serde_json::to_string_pretty( &json_schema).unwrap());
+            eprintln!("UISchema:\n {{}}", serde_json::to_string_pretty( & ui_object).unwrap());
+        }}
+
         assert_eq!(expected_json_schema, json_schema, "Actual(right) json schema different than expected (left)");
         assert_eq!(expected_ui_object, ui_object, "Actual(right) ui object different than expected (left)");
 


### PR DESCRIPTION
Make `cdsl` emit `ui:order` in UISchema in addition to `$$order` in JSONSchema. Makes the schemas properly render in `rjsf`. See [old](https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyIkJG9yZGVyIjpbImJvYXJkIiwibmV0d29yayIsImFkdmFuY2VkIl0sIiQkdmVyc2lvbiI6MSwiJHNjaGVtYSI6Imh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDQvc2NoZW1hIyIsImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJhZHZhbmNlZCI6eyIkJG9yZGVyIjpbImFwcFVwZGF0ZVBvbGxJbnRlcnZhbCJdLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInByb3BlcnRpZXMiOnsiYXBwVXBkYXRlUG9sbEludGVydmFsIjp7ImRlZmF1bHQiOjEwLCJtaW5pbXVtIjoxMCwidGl0bGUiOiJBcHBsaWNhdGlvbiB1cGRhdGUgcG9sbCBpbnRlcnZhbCIsInR5cGUiOiJpbnRlZ2VyIn19LCJyZXF1aXJlZCI6WyJhcHBVcGRhdGVQb2xsSW50ZXJ2YWwiXSwidGl0bGUiOiJBZHZhbmNlZCIsInR5cGUiOiJvYmplY3QifSwiYm9hcmQiOnsiJCRvcmRlciI6WyJjb3JlcyJdLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInByb3BlcnRpZXMiOnsiY29yZXMiOnsiZGVmYXVsdCI6MSwib25lT2YiOlt7ImVudW0iOlsxXSwidGl0bGUiOiJTaW5nbGUifSx7ImVudW0iOls0XSwidGl0bGUiOiJRdWFkIn1dLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsiY29yZXMiXSwidGl0bGUiOiJDUFUgQ29yZXMiLCJ0eXBlIjoib2JqZWN0In0sIm5ldHdvcmsiOnsiJCRvcmRlciI6WyJuZXR3b3JrcyJdLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInByb3BlcnRpZXMiOnsibmV0d29ya3MiOnsiaXRlbXMiOnsiJCRvcmRlciI6WyJzc2lkIiwicHNrIl0sImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJwc2siOnsidGl0bGUiOiJOZXR3b3JrIHBhc3N3b3JkIiwidHlwZSI6InN0cmluZyIsIndyaXRlT25seSI6dHJ1ZX0sInNzaWQiOnsidGl0bGUiOiJOZXR3b3JrIFNTSUQiLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJzc2lkIiwicHNrIl0sInRpdGxlIjoiV2lGaSBOZXR3b3JrIiwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbIm5ldHdvcmtzIl0sInRpdGxlIjoiTmV0d29yayBDb25uZWN0aW9uIiwidHlwZSI6Im9iamVjdCJ9fSwicmVxdWlyZWQiOlsiYm9hcmQiLCJuZXR3b3JrIiwiYWR2YW5jZWQiXSwidGl0bGUiOiJSZXNpbk9TIFRlY2hub2xvZ2ljIFRTLTQ5MDAgQ29uZmlndXJhdGlvbiIsInR5cGUiOiJvYmplY3QifSwidWlTY2hlbWEiOnsiYWR2YW5jZWQiOnsiYXBwVXBkYXRlUG9sbEludGVydmFsIjp7InVpOmhlbHAiOiJDaGVjayBmb3IgdXBkYXRlcyBldmVyeSBYIG1pbnV0ZXMifX0sImJvYXJkIjp7InVpOndhcm5pbmciOiJQbGVhc2UgbWFrZSBzdXJlIHRvIHNlbGVjdCB0aGUgY29ycmVjdCBudW1iZXIgb2YgQ1BVIENvcmVzIGZvciB5b3VyIGRldmljZS5cbioqRmFpbGluZyB0byBkbyBzbyB3aWxsIGJyaWNrIHlvdXIgZGV2aWNlKiouIn0sIm5ldHdvcmsiOnt9fX0=) vs [new](https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyIkc2NoZW1hIjoiaHR0cDovL2pzb24tc2NoZW1hLm9yZy9kcmFmdC0wNC9zY2hlbWEjIiwiJCR2ZXJzaW9uIjoxLCJ0aXRsZSI6IlJlc2luT1MgVGVjaG5vbG9naWMgVFMtNDkwMCBDb25maWd1cmF0aW9uIiwidHlwZSI6Im9iamVjdCIsImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicmVxdWlyZWQiOlsiYm9hcmQiLCJuZXR3b3JrIiwiYWR2YW5jZWQiXSwiJCRvcmRlciI6WyJib2FyZCIsIm5ldHdvcmsiLCJhZHZhbmNlZCJdLCJwcm9wZXJ0aWVzIjp7ImJvYXJkIjp7IiQkb3JkZXIiOlsiY29yZXMiXSwicHJvcGVydGllcyI6eyJjb3JlcyI6eyJkZWZhdWx0IjoxLCJvbmVPZiI6W3siZW51bSI6WzFdLCJ0aXRsZSI6IlNpbmdsZSJ9LHsiZW51bSI6WzRdLCJ0aXRsZSI6IlF1YWQifV0sInR5cGUiOiJpbnRlZ2VyIn19LCJyZXF1aXJlZCI6WyJjb3JlcyJdLCJ0aXRsZSI6IkNQVSBDb3JlcyIsInR5cGUiOiJvYmplY3QiLCJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2V9LCJuZXR3b3JrIjp7IiQkb3JkZXIiOlsibmV0d29ya3MiXSwicHJvcGVydGllcyI6eyJuZXR3b3JrcyI6eyJpdGVtcyI6eyIkJG9yZGVyIjpbInNzaWQiLCJwc2siXSwicHJvcGVydGllcyI6eyJwc2siOnsidGl0bGUiOiJOZXR3b3JrIHBhc3N3b3JkIiwidHlwZSI6InN0cmluZyIsIndyaXRlT25seSI6dHJ1ZX0sInNzaWQiOnsidGl0bGUiOiJOZXR3b3JrIFNTSUQiLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJzc2lkIiwicHNrIl0sInRpdGxlIjoiV2lGaSBOZXR3b3JrIiwidHlwZSI6Im9iamVjdCIsImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZX0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsibmV0d29ya3MiXSwidGl0bGUiOiJOZXR3b3JrIENvbm5lY3Rpb24iLCJ0eXBlIjoib2JqZWN0IiwiYWRkaXRpb25hbFByb3BlcnRpZXMiOmZhbHNlfSwiYWR2YW5jZWQiOnsiJCRvcmRlciI6WyJhcHBVcGRhdGVQb2xsSW50ZXJ2YWwiXSwicHJvcGVydGllcyI6eyJhcHBVcGRhdGVQb2xsSW50ZXJ2YWwiOnsiZGVmYXVsdCI6MTAsIm1pbmltdW0iOjEwLCJ0aXRsZSI6IkFwcGxpY2F0aW9uIHVwZGF0ZSBwb2xsIGludGVydmFsIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbImFwcFVwZGF0ZVBvbGxJbnRlcnZhbCJdLCJ0aXRsZSI6IkFkdmFuY2VkIiwidHlwZSI6Im9iamVjdCIsImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZX19fSwidWlTY2hlbWEiOnsiYWR2YW5jZWQiOnsiYXBwVXBkYXRlUG9sbEludGVydmFsIjp7InVpOmhlbHAiOiJDaGVjayBmb3IgdXBkYXRlcyBldmVyeSBYIG1pbnV0ZXMifSwidWk6b3JkZXIiOlsiYXBwVXBkYXRlUG9sbEludGVydmFsIl19LCJib2FyZCI6eyJ1aTpvcmRlciI6WyJjb3JlcyJdLCJ1aTp3YXJuaW5nIjoiUGxlYXNlIG1ha2Ugc3VyZSB0byBzZWxlY3QgdGhlIGNvcnJlY3QgbnVtYmVyIG9mIENQVSBDb3JlcyBmb3IgeW91ciBkZXZpY2UuXG4qKkZhaWxpbmcgdG8gZG8gc28gd2lsbCBicmljayB5b3VyIGRldmljZSoqLiJ9LCJuZXR3b3JrIjp7InVpOm9yZGVyIjpbIm5ldHdvcmtzIl19LCJ1aTpvcmRlciI6WyJib2FyZCIsIm5ldHdvcmsiLCJhZHZhbmNlZCJdfX0=) .
Decided to not remove `$$order` for now.

The number of test files changed highlights that these types of tests we have are highly coupled with the actual implementation.

This PR also contains a change to the test template that spits out the JSON text contents of all schemas in case of test failure - this was useful for mass-changing the test data files.

Fixes #59 