### PR TITLE
Add basic fuzzer configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This library is written in the Rust language and can be used:
 
 * [API documentation]
 * [Changelog]
+* [Maintainer documentation]
 
 ## Usage
 
@@ -124,7 +125,8 @@ the [license].
 [contact us]: https://forums.balena.io/
 [raise an issue]: https://github.com/balena-io-modules/balena-cdsl/issues/new
 [API documentation]: https://docs.rs/balena-cdsl/latest/balena_cdsl/
-[license]: https://github.com/balena-io-modules/balena-cdsl/blob/master/LICENSE
+[license]: ./LICENSE
 [Rust crate]: https://crates.io/crates/balena-cdsl
 [NPM package]: https://www.npmjs.com/package/balena-cdsl
-[Changelog]: https://github.com/balena-io-modules/balena-cdsl/blob/master/CHANGELOG.md
+[Changelog]: ./CHANGELOG.md
+[Maintainer documentation]: ./docs/MAINTAINER.md

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -1,0 +1,23 @@
+
+## Hello and welcome to CDSL, maintainer !
+
+This talks about how to run this project locally and how to make changes to it.
+ 
+You can just run `./ci/install.sh` to get all dependencies going. This will install Rust and Node via NVM - please review the script before running, to see if this is what you want on your machine.
+
+To make sure everything is working run `./ci/test.sh` - this will launch all the Rust tests and then package npm package and run node tests on it.
+
+ 
+## Fuzzing
+Fuzz tests are not included in the CI runs as they typically take a long time to run and the timing is quite unpredictable.  
+We're using pretty standard [cargo fuzz] configuration with seeds here, based on [libFuzzer].  
+To run the default fuzzer configuration do `fuzz/run-fuzzer.sh`.  
+This will use seed jellyschema files from `fuzz/seeds` to jumpstart the process.  
+You can cancel the fuzzing at any time by pressing `ctrl-c`. If you then run the fuzzer again, it will start where it left off - the temporary state is saved to `fuzz/corpus`  
+
+### Fuzzing targets
+It is only possible to fuzz one target at the time, the default target is `any_input` - that tests whether random input will crash the CDSL (make it panic).
+TODO: add a fuzzing target where we make sure there is no `Err` when the yaml validates as jellyschema.
+
+[cargo fuzz]: https://fuzz.rs/book/cargo-fuzz/guide.html
+[libFuzzer]: https://llvm.org/docs/LibFuzzer.html

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1,0 +1,418 @@
+[[package]]
+name = "aho-corasick"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arbitrary"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "balena-cdsl"
+version = "0.10.0"
+dependencies = [
+ "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-merge-keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "balena-cdsl-fuzz"
+version = "0.0.1"
+dependencies = [
+ "balena-cdsl 0.10.0",
+ "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.1.0"
+source = "git+https://github.com/rust-fuzz/libfuzzer-sys.git#4a413199b5cb1bbed6a1d157b2342b925f8464ac"
+dependencies = [
+ "arbitrary 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "yaml-merge-keys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum arbitrary 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c7d1523aa3a127adf8b27af2404c03c12825b4c4d0698f01648d63fa9df62ee"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6c5dd2c094474ec60a6acaf31780af270275e3153bafff2db5995b715295762e"
+"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
+"checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
+"checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
+"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2d8c1eb210a0e91e24feb8ccd6f7484a5d442bfdf2ff179204b3a1d16e1029cc"
+"checksum wasm-bindgen-backend 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab9a5e88bf5dea5be82bb5f8b68c0f8e550675796ac88570ea4c4e89923413"
+"checksum wasm-bindgen-macro 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "52909345426e198a0d34f63526f9f4d86ca50c24b4a22a019d0bc86570ffe1e3"
+"checksum wasm-bindgen-macro-support 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2a130a5906bd540390cda0a28e7f8a2d450222461beb92a5eb5c6a33b8b8bc2a"
+"checksum wasm-bindgen-shared 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "9c406cd5b42c36db6f76f17d28bcd26187fd90cda686231f3d04de07a716fc3a"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum yaml-merge-keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06dc230d3ea07c633fb8ef981e4a0c4d956d9588d0e75244c86f618527ac0e73"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+
+[package]
+name = "balena-cdsl-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.balena-cdsl]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies.serde_yaml]
+version = "0.8"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "any_input"
+path = "fuzz_targets/any_input.rs"

--- a/fuzz/fuzz_targets/any_input.rs
+++ b/fuzz/fuzz_targets/any_input.rs
@@ -1,0 +1,17 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate balena_cdsl;
+extern crate serde_yaml;
+
+use balena_cdsl::output::generator::Generator;
+
+// this is a fuzz target that makes sure that we do not crash given arbitrary data
+fuzz_target!(|data: &[u8]| {
+if let Ok(data) = std::str::from_utf8(data) {
+    if let Ok(yaml_schema) = serde_yaml::from_str(data) {
+        if let Ok(generator) = Generator::with(yaml_schema) {
+            generator.generate();
+        }
+    }
+}
+});

--- a/fuzz/run-fuzzer.sh
+++ b/fuzz/run-fuzzer.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PARENT="$HERE/../"
+
+(test -x "${HOME}/.cargo/bin/cargo-fuzz" || cargo install cargo-fuzz)
+
+# it is important for `cargo fuzz` to be run from the project root
+cd "$PARENT"
+
+# run `any_input` target using `seeds` as a start point and put new corpus state into `corpus`
+cargo fuzz run any_input "$HERE/corpus" "$HERE/seeds" -j 6 --all-features

--- a/fuzz/seeds/balena-os.yml
+++ b/fuzz/seeds/balena-os.yml
@@ -1,0 +1,228 @@
+---
+title: BalenaOS configuration schema
+version: 1
+#
+# Configuration files (aka targets)
+#
+mapping:
+  targets:
+    config-json:
+      type: file
+      format: json
+      location:
+        partition: resin-boot
+        path: /config.json
+    logo:
+      type: file
+      format: binary
+      location:
+        partition: resin-boot
+        path: /splash/resin-logo.png
+    system-connections:
+      type: fileset
+      format: ini
+      location:
+        partition: resin-boot
+        path: /system-connections
+    system-proxy-configuration:
+      type: file
+      format: redsocks  # NEW - not in a spec
+      location:
+        partition: resin-boot
+        path: /system-proxy/redsocks.conf
+    system-proxy-whitelist:
+      type: file
+      format: text  # NEW - not in a spec
+      location:
+        partition: resin-boot
+        path: /system-proxy/no_proxy
+properties:
+  #
+  # Advanced section
+  #
+  - advanced:
+      mapping:
+        # All advanced.properties.* inherits this target, no need to repeat it
+        target: config-json
+      properties:
+        - appUpdatePollInterval:
+            title: Check for updates every X minutes
+            type: integer
+            default: 10
+            min: 10
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: appUpdatePollInterval
+        - hostname:
+            title: Device hostname
+            type: hostname?
+            default: balena
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: hostname
+        - persistentLogging:
+            title: Do you want to enable persistent logging?
+            type: boolean
+            default: false
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: persistentLogging
+        - country:
+            title: Country
+            type: string?
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: country
+        - dnsServers:
+            title: DNS servers
+            type: stringlist  # NEW - not in a spec
+            separator: " "    # NEW - not in a spec
+            items:
+              # https://github.com/balena-os/meta-balena/blob/master/meta-resin-common/recipes-connectivity/resin-net-config/resin-net-config/resin-net-config#L34-L39
+              type: dnsmasq-address  # NEW - not in a spec
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: dnsServers
+        - ntpServers: # chronyc add server $VALUE
+            type: stringlist  # NEW - not in a spec
+            separator: " "    # NEW - not in a spec
+            items:
+              # https://github.com/balena-os/meta-balena/blob/master/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config#L19
+              type: chrony-address  # NEW - not in a spec
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: ntpServers
+        - randomMacAddressScan:
+            title: Randomize MAC address?
+            type: boolean?
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: randomMacAddressScan
+        - udevRules:
+            title: udev rules
+            type: object
+            keys:  # NEW - not in a spec
+              title: Priority
+              type: string
+              pattern: ^\d+$
+            values:  # NEW - not in a spec
+              title: Rule
+              type: string
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: os.udevRules
+
+        - sshKeys:
+            title: SSH keys
+            type: array?
+            items:
+              title: SSH key
+              type: string
+            mapping:
+              # target inherited from properties.advanced.mapping.target
+              path: sshKeys
+  #
+  # Binary blobs
+  #
+  - blobs:
+      properties:
+        - logo:
+            title: Boot logo
+            type: file?
+            mapping:
+              target: logo
+            #                       - dtb: TODO
+            # Where does it end up ?
+            # What is the target filename?
+            # Would this overwrite files? How is hup going to work with that?
+  #
+  # WiFi networks
+  #
+  - network:
+      title: Networking
+      type: array?
+      items:
+        uniqueItems:
+          - id
+          - ssid
+        properties:
+          - id: # Hidden property, just for /system-connections/*:connection.id computation
+              # Do we want to make this visible to the user? Probably not, it's not useful.
+              type: string
+              hidden: true
+              formula: super.ssid | slugify
+              mapping:
+                path: connection.id
+          - ssid:
+              title: WiFi SSID
+              type: string
+              mapping:
+                path: wifi.ssid
+          - password:
+              title: WiFi Passphrase
+              type: password
+              mapping:
+                path: wifi-security.psk
+        mapping:
+          target: system-connections
+          filename:
+            formula: this.id
+          template:
+            connection:
+              type: wifi
+            wifi:
+              hidden: true
+              mode: infrastructure
+            wifi-security:
+              auth-alg: open
+              key-mgmt: wpa-psk
+            ipv4:
+              method: auto
+            ipv6:
+              addr-gen-mode: stable-privacy
+              method: auto
+  #
+  # Proxy configuration
+  #
+  - proxy:
+      title: Proxy configuration
+      properties:
+        - proxyWhitelistIPs:
+            title: Whitelist IP addresses
+            help: List of IP addresses / ranges that are not routed through proxy
+            type: stringlist
+            separator: \n  # TODO - Check that this will be read as a newline
+            items:
+              # https://github.com/balena-os/meta-balena/blob/master/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config#L66-L73
+              type: iptables-address  # NEW - not in a spec
+            mapping:
+              target: system-proxy-whitelist
+        - redsocks:
+            properties:
+              - proxyType:
+                  type: string
+                  enum:
+                    - socks5
+                    - http-connect
+                  mapping:
+                    # target inherited from properties.proxy.properties.redsocks.mapping.target
+                    path: redsocks.type
+              - server:
+                  type: ipv4
+                  mapping:
+                    # target inherited from properties.proxy.properties.redsocks.mapping.target
+                    path: redsocks.ip
+              - port:
+                  type: port
+                  mapping:
+                    # target inherited from properties.proxy.properties.redsocks.mapping.target
+                    path: redsocks.port
+            mapping:
+              target: system-proxy-configuration
+              template:
+                base:
+                  log_debug: off
+                  log_info: on
+                  log: stderr
+                  redirector: iptables
+

--- a/fuzz/seeds/resin-cli.yml
+++ b/fuzz/seeds/resin-cli.yml
@@ -1,0 +1,72 @@
+title: resin-cli demo
+version: 1
+definitions:
+  bootPartition: &BOOT_PARTITION
+    partition: 1
+mapping:
+  targets:
+    config_json:
+      type: file
+      format: json
+      location:
+        <<: *BOOT_PARTITION
+        path: /config.json
+    resin_wifi:
+      type: file
+      format: ini
+      location:
+        <<: *BOOT_PARTITION
+        path: /system-connections/resin-wifi
+properties:
+  - network:
+      collapsible: false
+      title: Network
+      properties:
+        - ssid:
+            title: Network SSID
+            type: string
+            minLength: 1
+            maxLength: 32
+            mapping:
+              target: resin_wifi
+              path: wifi.ssid
+        - passphrase:
+            title: Network Key
+            type: password
+            minLength: 8
+            mapping:
+              target: resin_wifi
+              path: wifi-security.psk
+      mapping:
+        target: resin_wifi
+        template:
+          connection:
+            type: wifi
+          wifi:
+            hidden: true
+            mode: infrastructure
+          wifi-security:
+            auth-alg: open
+            key-mgmt: wpa-psk
+          ipv4:
+            method: auto
+          ipv6:
+            addr-gen-mode: stable-privacy
+            method: auto
+  - advanced:
+      title: Advanced
+      collapsed: true
+      properties:
+        - hostname:
+            title: Device Hostname
+            type: string
+            mapping:
+              target: config_json
+              path: hostname
+        - persistentLogging:
+            title: Do you want to enable persistent logging?
+            type: boolean
+            default: false
+            mapping:
+              target: config_json
+              path: persistentLogging

--- a/fuzz/seeds/technologic.yml
+++ b/fuzz/seeds/technologic.yml
@@ -1,0 +1,45 @@
+---
+version: 1
+title: ResinOS Technologic TS-4900 Configuration
+properties:
+  - board:
+      title: CPU Cores
+      warning: |-
+        Please make sure to select the correct number of CPU Cores for your device.
+        **Failing to do so will brick your device**.
+      properties:
+        - cores:
+            type: integer
+            default: 1
+            enum:
+              - value: 1
+                title: Single
+              - value: 4
+                title: Quad
+  - network:
+      title: Network Connection
+      properties:
+        - networks:
+            type: array
+            items:
+              title: WiFi Network
+              properties:
+                - ssid:
+                    title: Network SSID
+                    type: string
+                - psk:
+                    title: Network password
+                    type: password
+              warning: |-
+                In order to have usable WiFi connectivity, make sure you have attached
+                a WiFi antenna to your WiFi module.
+  - advanced:
+      title: Advanced
+      collapsed: true
+      properties:
+        - appUpdatePollInterval:
+            title: Application update poll interval
+            help: Check for updates every X minutes
+            type: integer
+            min: 10
+            default: 10


### PR DESCRIPTION
Add standard `cargo-fuzz` configuration with seeds - a basis for us to use the fuzzer later to find corner cases - see the last paragraph below.

This just tests if given random input the whole stack does not panic.
If there is `Err` it is considered ok.
Please see `docs/MAINTAINER.md` for documentation on running.
I've ran this for half an hour and it did not find any crashes.

The plan would be to have this, and then as the next step (next PR) add
a fuzzing target that would use the new validator library, to check if
there are no `Err` returned if the input yaml is a valid jellyschema -
here I suspect it will find some corner cases.

Fixes #17 