### PR TITLE
Wasm fn feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 [lib]
 crate-type = ["lib", "cdylib"]
 
+[features]
+default = []
+disable-wasm-bindings = []
+
 [dependencies.heck]
 version = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,5 +38,5 @@
 //! [Semantic Versioning]: https://semver.org/
 pub mod dsl;
 pub mod output;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "disable-wasm-bindings")))]
 mod wasm;


### PR DESCRIPTION
**Problem**

* `cdsl` have a function `generate_ui`
* if `reconfix` does use `cdsl` as a dependency, this `generate_ui` fn is in the `reconfix` bindings as well, which is something I do not want
* if I define `generate_ui` in the `reconfix`, it doesn't compile, because linker complaints about two functions with the same name

In other words. If `cdsl` is used to generate `balena-cdsl` NPM package, it's good as it is now. But if you'd like to use `cdsl` as a dependency and you do not want to have `cdsl` JS bindings in your NPM package (like `reconfix`), there's no way.

**What this PR does**

* adds feature `disable-wasm-bindings`
* `wasm.rs` is gated with target arch `wasm32` & `not(feature = "disable-wasm-bindings"))`

By default, nothing changes. But for the `reconfix` I can say something like - I'd like to use `cdsl`, but without `cdsl` JS bindings.

**Feature name**

Initially, I was thinking about a feature called `npm-package` and build scripts update. I have found that `wasm-pack build` does support `-- --features "npm-package"` (added to 0.6). Unfortunately, `wasm-pack test` doesn't. Thus it must be enabled by default and we have to introduce disabling feature. Then the `disable-wasm-bindings` it is.