### PR TITLE
`version` keyword available and passed through on every schema level. 

### DIFF
--- a/src/dsl/schema/mod.rs
+++ b/src/dsl/schema/mod.rs
@@ -14,10 +14,7 @@ mod dynamic;
 
 /// Represents the root of the yaml DSL document
 #[derive(Clone, Debug)]
-pub struct DocumentRoot {
-    pub version: u64,
-    pub schema: Option<Schema>,
-}
+pub struct DocumentRoot(Schema);
 
 /// A first-class collection of `NamedSchema`'s, has convenience methods exposed
 #[derive(Clone, Debug)]
@@ -37,6 +34,7 @@ pub struct NamedSchema {
 /// Everything that a schema at any level can represent, see schema and subschema in the spec
 #[derive(Clone, Debug)]
 pub struct Schema {
+    pub version: Option<u64>,
     pub object_type: ObjectType,
     pub annotations: Annotations,
     /// children of a schema are all schemas defined inside of this schema
@@ -90,6 +88,21 @@ impl NamedSchema {
     /// Unpacks named schema into (name, schema)
     pub fn unpack(&self) -> (&str, &Schema) {
         (self.name.as_ref(), &self.schema)
+    }
+}
+
+impl Schema {
+    pub fn with_version(self, version: u64) -> Schema {
+        Schema {
+            version: Some(version),
+            ..self
+        }
+    }
+}
+
+impl DocumentRoot {
+    pub fn schema(self) -> Schema {
+        self.0
     }
 }
 

--- a/src/output/generator.rs
+++ b/src/output/generator.rs
@@ -29,7 +29,7 @@ impl Generator {
     /// Generates JSON Schema & UI Object
     pub fn generate(self) -> (serde_json::Value, serde_json::Value) {
         let source_schema = self.compiled_schema.compiled();
-        let json_schema = JsonSchema::from(&source_schema);
+        let json_schema = JsonSchema::from(source_schema.clone());
         let ui_object = UiObjectRoot::from(source_schema.clone());
         let serialized_json_schema =
             serde_json::to_value(json_schema).expect("Internal error: inconsistent schema: json schema");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -12,9 +12,8 @@ mod serialization;
 
 /// JSON Schema wrapper
 pub struct JsonSchema<'a> {
-    version: u64,
     schema_url: &'a str,
-    root: Option<&'a Schema>,
+    root: Schema,
 }
 
 /// It's different than UiObject as the root is nameless in the output
@@ -24,12 +23,6 @@ pub struct UiObjectRoot(Option<UiObjectProperty>);
 /// UI Object wrapper
 #[derive(Clone, Debug, Serialize)]
 pub struct UiObject(HashMap<String, UiObjectProperty>);
-
-impl UiObject {
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 struct UiOptions {
@@ -84,6 +77,12 @@ impl UiObjectRoot {
             None => true,
             Some(property) => property.is_empty(),
         }
+    }
+}
+
+impl UiObject {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/src/output/serialization/json_schema.rs
+++ b/src/output/serialization/json_schema.rs
@@ -18,21 +18,17 @@ impl<'a> Serialize for JsonSchema<'a> {
     {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("$schema", &self.schema_url)?;
-        map.serialize_entry("$$version", &self.version)?;
 
-        if let Some(schema) = self.root {
-            serialize_schema(schema, &mut map)?
-        }
+        serialize_schema(&self.root, &mut map)?;
 
         map.end()
     }
 }
 
-impl<'a> From<&'a DocumentRoot> for JsonSchema<'a> {
-    fn from(schema: &'a DocumentRoot) -> Self {
+impl<'a> From<DocumentRoot> for JsonSchema<'a> {
+    fn from(root: DocumentRoot) -> Self {
         JsonSchema {
-            root: schema.schema.as_ref(),
-            version: schema.version,
+            root: root.schema(),
             schema_url: SCHEMA_URL,
         }
     }

--- a/src/output/serialization/properties.rs
+++ b/src/output/serialization/properties.rs
@@ -38,11 +38,11 @@ where
     E: Error,
     S: SerializeMap<Ok = O, Error = E>,
 {
-    for title in &schema.annotations.title {
+    serialize_object_type(&schema.object_type, map)?;
+
+    if let Some(title) = &schema.annotations.title {
         map.serialize_entry("title", &title)?;
     }
-
-    serialize_object_type(&schema.object_type, map)?;
 
     if let Some(children) = &schema.children {
         serialize_schema_list(children, map)?;
@@ -63,5 +63,10 @@ where
     if let Some(formula) = &schema.formula {
         map.serialize_entry("$$formula", &formula)?;
     }
+
+    if let Some(version) = &schema.version {
+        map.serialize_entry("$$version", &version)?;
+    }
+
     Ok(())
 }

--- a/src/output/serialization/ui_object.rs
+++ b/src/output/serialization/ui_object.rs
@@ -16,8 +16,8 @@ use crate::dsl::schema::Widget;
 use crate::dsl::schema::object_types::RawObjectType;
 
 impl From<DocumentRoot> for UiObjectRoot {
-    fn from(schema: DocumentRoot) -> UiObjectRoot {
-        UiObjectRoot(schema.schema.map(|schema| schema.into()))
+    fn from(root: DocumentRoot) -> Self {
+        UiObjectRoot(Some(root.schema().into()))
     }
 }
 
@@ -29,7 +29,7 @@ impl From<SchemaList> for UiObject {
             .filter_map(|entry| {
                 let property: UiObjectProperty = entry.schema.clone().into();
                 if !property.is_empty() {
-                    Some((entry.name.clone(), entry.schema.clone().into()))
+                    Some((entry.name.clone(), property))
                 } else {
                     None
                 }

--- a/tests/data/schema/nested_properties/input-schema.yml
+++ b/tests/data/schema/nested_properties/input-schema.yml
@@ -5,6 +5,7 @@ properties:
       title: Top level property with no type specified
       properties:
         - second:
+            version: 1
             title: Second level property
             type: string
 

--- a/tests/data/schema/nested_properties/output-json-schema.json
+++ b/tests/data/schema/nested_properties/output-json-schema.json
@@ -23,6 +23,7 @@
             ],
             "properties": {
                 "second": {
+                    "$$version": 1,
                     "type": "string",
                     "title": "Second level property"
                 }


### PR DESCRIPTION
* if version is not specified on the root level, we default the version
to 1 and emit it at the root level
* if there is no version specified at the non-root level - we don't emit
anything, assuming that the version at the root level is current
* if there is a version specified at the non-root level we pass it
through
* the only valid version specifier remains `1`

Fixes #44 